### PR TITLE
Typo fixes

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 1.2.8 Jan 8th 2013
-	- Add GeoIPUseUseFirstNunPrivateXForwardedForIP option ( Boris Zentner )
-	- Support Aapche 2.4 ( Boris Zentner )
+	- Add GeoIPUseFirstNonPrivateXForwardedForIP option ( Boris Zentner )
+	- Support Apache 2.4 ( Boris Zentner )
         - Use GeoIP_id_by_addr_v6 instead of GeoIP_country_id_by_addr_v6 ( Boris Zentner )
         - Include util_script.h to silence warning about ap_add_common_vars ( Boris Zentner )
 1.2.7 Aug 23th 2011

--- a/README
+++ b/README
@@ -84,7 +84,7 @@ been updated, set the `CheckCache` flag:
     GeoIPDBFile /path/to/GeoIP.dat CheckCache
 
 Before making a call to the database, geoip will check the GeoIP.dat
-file to see if it has changed. If it has it, then it will reload the
+file to see if it has changed. If it has, then it will reload the
 file. With this option, you do not have to restart Apache when you
 update your GeoIP databases.
 


### PR DESCRIPTION
Changelog: New directive 'GeoIPUseFirstNumPrivateXForwardedForIP' has two typos. Correct mis-spelled 'Apache'. Remove un-necessary word in the README (I realize the README is generated via pandoc, but there's no straightforward way to submit corrections to the website docs).
