### PR TITLE
Feature/reliable status

### DIFF
--- a/mod_geoip.c
+++ b/mod_geoip.c
@@ -214,7 +214,7 @@ static apr_status_t geoip_cleanup(void *cfgdata)
     return APR_SUCCESS;
 }
 
-/* initialize geoip once per server ( even virtal server! ) */
+/* initialize geoip any per server ( any virtual server! ) */
 static void geoip_server_init(apr_pool_t * p, server_rec * s)
 {
     geoip_server_config_rec *cfg;

--- a/mod_geoip.c
+++ b/mod_geoip.c
@@ -214,7 +214,7 @@ static apr_status_t geoip_cleanup(void *cfgdata)
     return APR_SUCCESS;
 }
 
-/* initialize geoip any per server ( any virtual server! ) */
+/* initialize geoip any server ( any virtual server! ) */
 static void geoip_server_init(apr_pool_t * p, server_rec * s)
 {
     geoip_server_config_rec *cfg;

--- a/mod_geoip.c
+++ b/mod_geoip.c
@@ -140,7 +140,7 @@ static int _is_private(uint32_t ipnum)
     return 0;
 }
 
-char *_get_ip_from_xff(request_rec r, const char *xffheader)
+char *_get_ip_from_xff(request_rec *r, const char *xffheader)
 {
     char *xff = apr_pstrdup(r->pool, xffheader);
     char *xff_ip, *break_ptr;

--- a/mod_geoip.c
+++ b/mod_geoip.c
@@ -277,11 +277,6 @@ static void geoip_child_init(apr_pool_t * p, server_rec * s)
                     flags =
                         (cfg->GeoIPFlags2[i] ==
                          GEOIP_UNKNOWN) ? cfg->GeoIPFlags : cfg->GeoIPFlags2[i];
-#if 0
-                    if (flags & (GEOIP_MEMORY_CACHE | GEOIP_MMAP_CACHE)) {
-                        continue;
-                    }
-#endif
                     if (cfg->gips[i]) {
                         GeoIP_delete(cfg->gips[i]);
                     }


### PR DESCRIPTION

```
Linux tiara.log-1 2.6.18-308.el5 #1 SMP Fri Jan 27 17:17:51 EST 2012 x86_64 x86_64 x86_64 GNU/Linux
```
```
warning: no loadable sections found in added symbol-file system-supplied DSO at 0x7fff379f7000
Core was generated by `/daum/program/apache/bin/httpd -k restart'.
Program terminated with signal 11, Segmentation fault.
#0  0x0000003d2320d9eb in read () from /lib64/libpthread.so.0
(gdb) info threads
  34 Thread 26881  0x0000003d22274e1b in malloc () from /lib64/libc.so.6
  33 Thread 26882  0x0000003d222306f7 in kill () from /lib64/libc.so.6
  32 Thread 26883  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  31 Thread 26884  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  30 Thread 26885  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  29 Thread 26886  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  28 Thread 26887  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  27 Thread 26888  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  26 Thread 26889  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  25 Thread 26890  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  24 Thread 26891  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  23 Thread 26892  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  22 Thread 26893  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  21 Thread 26894  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  20 Thread 26895  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  19 Thread 26896  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  18 Thread 26897  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  17 Thread 26898  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  16 Thread 26899  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  15 Thread 26900  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  14 Thread 26901  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  13 Thread 26902  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  12 Thread 26903  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  11 Thread 26904  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  10 Thread 26905  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  9 Thread 26906  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  8 Thread 26907  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  7 Thread 26908  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  6 Thread 26909  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  5 Thread 26910  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  4 Thread 26911  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  3 Thread 26912  0x0000003d2320af59 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  2 Thread 26913  0x0000003d2320dc0b in accept () from /lib64/libpthread.so.0
* 1 Thread 0x2b236c20c080 (LWP 26879)  0x0000003d2320d9eb in read () from /lib64/libpthread.so.0
(gdb) thread 33
[Switching to thread 33 (Thread 26882)]#0  0x0000003d222306f7 in kill () from /lib64/libc.so.6
(gdb) bt full
#0  0x0000003d222306f7 in kill () from /lib64/libc.so.6
No symbol table info available.
#1  <signal handler called>
No symbol table info available.
#2  0x00002b236cf1ea5b in _GeoIP_seek_record_gl () from /daum/program/apache/modules/mod_geoip.so
No symbol table info available.
#3  0x00002b236cf1e9ef in _GeoIP_seek_record_gl () from /daum/program/apache/modules/mod_geoip.so
No symbol table info available.
#4  0x00002b236cf1b8d2 in geoip_header_parser (r=0x3) at mod_geoip.c:573
        orgorisp = <value optimized out>
        ipaddr = 0x2aaaac0008e8 "HN", <incomplete sequence \317>
        free_me = 0x2aaaac000960 "\350\b"
        country_id = 0
        continent_code = <value optimized out>
        country_code = <value optimized out>
        country_name = 0x222ce0 <Address 0x222ce0 out of bounds>
        region_name = 0x1ac002558 <Address 0x1ac002558 out of bounds>
        databaseType = <value optimized out>
        gir = <value optimized out>
        giregion = <value optimized out>
        i = 1101377328
        netspeed = <value optimized out>
        ipaddr_ptr = <value optimized out>
        comma_ptr = <value optimized out>
#5  0x00002aaaac000990 in ?? ()
No symbol table info available.
#6  0x0000000041a5af30 in ?? ()
No symbol table info available.
#7  0x0000000000453d4d in gen_unique_id ()
No symbol table info available.
#8  0x000000000042efdd in ap_read_request ()
No symbol table info available.
#9  0x000000000046ea9c in ap_process_http_connection ()
No symbol table info available.
#10 0x0000000000442df1 in ap_process_connection ()
No symbol table info available.
#11 0x0000000000485b21 in worker_thread ()
No symbol table info available.
#12 0x0000003d2320677d in start_thread () from /lib64/libpthread.so.0
No symbol table info available.
#13 0x0000003d222d49ad in clone () from /lib64/libc.so.6
No symbol table info available.
```