### PR TITLE
Issue #27: Add option to remove port number suffix from IP Address

### DIFF
--- a/mod_geoip.c
+++ b/mod_geoip.c
@@ -350,7 +350,7 @@ static char *get_ip_address_without_port(const char *s)
 	char* ptr = strchr(s, ':');
 
     if (ptr == NULL) {
-		// IP address does not contain port number - return original string
+        // IP address does not contain port number - return original string
         return (char *)s;
     }
 


### PR DESCRIPTION
### Solution:
Add option to remove port number suffix from IP Address

Option added:
    - GeoIPRemovePortNumberSuffixFromIP On

### Testing:

**Originally - with option `GeoIPRemovePortNumberSuffixFromIP` not set:**

Apache configured as follows:
```
<IfModule mod_geoip.c>
    GeoIPEnable On
    GeoIPDBFile /usr/share/GeoIP/GeoIP.dat
    GeoIPUseLastXForwardedForIP On
    GeoIPOutput Env
    GeoIPScanProxyHeaders On
</IfModule>
```

Checking environment variables on the received request in PHP server-side code:
![image](https://user-images.githubusercontent.com/51844732/159187666-b7c1c4ad-b835-492a-9bdc-f8912f0eeeec.png)


**After changes - with option `GeoIPRemovePortNumberSuffixFromIP` set:**

Apache configured as follows:
```
<IfModule mod_geoip.c>
    GeoIPEnable On
    GeoIPDBFile /usr/share/GeoIP/GeoIP.dat
    GeoIPUseLastXForwardedForIP On
    GeoIPRemovePortNumberSuffixFromIP On
    GeoIPOutput Env
    GeoIPScanProxyHeaders On
</IfModule>
```

Checking environment variables on the received request in PHP server-side code:
![image](https://user-images.githubusercontent.com/51844732/159187534-3070922c-df8d-4c87-9516-14496b8a7a6d.png)

Observed that GEOIP_ADDR shows IP with port number suffix stripped, and now `GEOIP_COUNTRY_CODE` and other GEOIP environment variables are set.
